### PR TITLE
fix: update contact email in CONTRIBUTING guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The following are guidelines for contributing to V0-Clone, which is a modern rec
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [your-email@example.com].
+This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [dsimoespaiva@gmail.com].
 
 ## How Can I Contribute?
 


### PR DESCRIPTION
fix: add contact email in CONTRIBUTING guidelines

Add placeholder email address with correct contact information to ensure proper reporting channel for code of conduct issues.